### PR TITLE
client/index.js: Remove message prompt

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -47,8 +47,6 @@ function start() {
     });
   }, 1000); // checking every second should be good enough
 
-  process.stdout.write('> ');
-
   dis.on('input', (input) => {
     if (input.startsWith('/')) {
       console.log('Commands are not implemented yet.');
@@ -61,7 +59,6 @@ function start() {
         dis.printError(error.Error);
       });
     }
-    process.stdout.write('> ');
   });
 
   dis.on('quit', () => {


### PR DESCRIPTION
I feel that the '>' prompt isn't really necessary and due to the way the client works it usually just makes a bit of a mess, with the prompt being written on top of by incoming messages